### PR TITLE
fix issue set_window_title.

### DIFF
--- a/realtime_plot/__init__.py
+++ b/realtime_plot/__init__.py
@@ -202,11 +202,11 @@ class RealtimePlotter(object):
 
         if values is None:
 
-            self.fig.canvas.set_window_title('Waiting for data ...')
+            self.fig.canvas.manager.set_window_title('Waiting for data ...')
 
         else:
 
-            self.fig.canvas.set_window_title(self.window_name)
+            self.fig.canvas.manager.set_window_title(self.window_name)
 
             yvals = values[2:] if self.sideline else values
 


### PR DESCRIPTION
Fix: resolved AttributeError: 'FigureCanvasTkAgg' object has no attribute 'set_window_title' from f.canvas.set_window_title(name) to f.canvas.manager.set_window_title(name) 
Cause: matplotlib upgrade version to 3.7.2
Ref: Issue #https://github.com/Udayraj123/OMRChecker/pull/56